### PR TITLE
added cert-manager RBAC files to linkerd app

### DIFF
--- a/flux/helm-example/apps/linkerd/cert-manager-rbac.yaml
+++ b/flux/helm-example/apps/linkerd/cert-manager-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-secret-creator
+  namespace: linkerd
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-secret-creator-binding
+  namespace: linkerd
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: linkerd
+roleRef:
+  kind: Role
+  name: cert-manager-secret-creator
+  apiGroup: rbac.authorization.k8s.io

--- a/flux/helm-example/apps/linkerd/kustomization.yaml
+++ b/flux/helm-example/apps/linkerd/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - linkerd-enterprise-secret.yaml
   - helmrelease-linkerd-crds.yaml
   - helmrelease-linkerd-control-plane.yaml
+  - cert-manager-rbac.yaml

--- a/flux/helm-example/apps/linkerd/linkerd-issuers-certs.yaml
+++ b/flux/helm-example/apps/linkerd/linkerd-issuers-certs.yaml
@@ -23,12 +23,6 @@ spec:
   privateKey:
     algorithm: ECDSA
   secretName: linkerd-identity-trust-anchor
-  secretTemplate:
-    annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cert-manager,linkerd"  # Control destination namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cert-manager,linkerd" # Control auto-reflection namespaces
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer


### PR DESCRIPTION
Added cert-manager RBAC files to linkerd app to allow cert-manager the ability to create and update secrets in the linkerd-namespace so we don't have to use a third-party tool like Reflector and reduce the number of dependencies. 