### PR TITLE
final touches on bel-flux-helm example

### DIFF
--- a/flux/helm-example/apps/linkerd-buoyant/helmrelease-linkerd-buoyant.yaml
+++ b/flux/helm-example/apps/linkerd-buoyant/helmrelease-linkerd-buoyant.yaml
@@ -18,6 +18,6 @@ spec:
         name: linkerd-buoyant
         namespace: linkerd-buoyant
   values:
-    licenseSecret: buoyant-license
+    licenseSecret: buoyant-enterprise-license
     metadata:
       agentName: bel-flux-helm-example

--- a/flux/helm-example/apps/linkerd-buoyant/linkerd-enterprise-secret.yaml
+++ b/flux/helm-example/apps/linkerd-buoyant/linkerd-enterprise-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   creationTimestamp: null
-  name: buoyant-license
+  name: buoyant-enterprise-license
   namespace: linkerd-buoyant
 spec:
   encryptedData:
@@ -11,5 +11,5 @@ spec:
   template:
     metadata:
       creationTimestamp: null
-      name: buoyant-license
+      name: buoyant-enterprise-license
       namespace: linkerd-buoyant

--- a/flux/helm-example/apps/linkerd/cert-manager-rbac.yaml
+++ b/flux/helm-example/apps/linkerd/cert-manager-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-secret-creator
+  namespace: linkerd
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-secret-creator-binding
+  namespace: linkerd
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: linkerd
+roleRef:
+  kind: Role
+  name: cert-manager-secret-creator
+  apiGroup: rbac.authorization.k8s.io

--- a/flux/helm-example/apps/linkerd/helmrelease-linkerd-control-plane.yaml
+++ b/flux/helm-example/apps/linkerd/helmrelease-linkerd-control-plane.yaml
@@ -18,7 +18,7 @@ spec:
         name: linkerd
         namespace: linkerd
   values:
-    licenseSecret: buoyant-license
+    licenseSecret: buoyant-enterprise-license
     linkerd-control-plane:
       identity:
         externalCA: true
@@ -43,7 +43,7 @@ spec:
             valueFrom:
               secretKeyRef:
                 key: license
-                name: custom-license-secret
+                name: buoyant-enterprise-license
       proxyInjector:
         additionalEnv:
           - name: LICENSE

--- a/flux/helm-example/apps/linkerd/kustomization.yaml
+++ b/flux/helm-example/apps/linkerd/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - linkerd-enterprise-secret.yaml
   - helmrelease-linkerd-crds.yaml
   - helmrelease-linkerd-control-plane.yaml
+  - cert-manager-rbac.yaml

--- a/flux/helm-example/apps/linkerd/kustomization.yaml
+++ b/flux/helm-example/apps/linkerd/kustomization.yaml
@@ -4,9 +4,9 @@ namespace: linkerd
 resources:
   - namespace.yaml
   - helmrepo.yaml
+  - cert-manager-rbac.yaml
   - linkerd-issuers-certs.yaml
   - linkerd-ca-trust-bundle.yaml
   - linkerd-enterprise-secret.yaml
   - helmrelease-linkerd-crds.yaml
   - helmrelease-linkerd-control-plane.yaml
-  - cert-manager-rbac.yaml

--- a/flux/helm-example/apps/linkerd/linkerd-enterprise-secret.yaml
+++ b/flux/helm-example/apps/linkerd/linkerd-enterprise-secret.yaml
@@ -3,7 +3,7 @@ apiVersion: bitnami.com/v1alpha1
 kind: SealedSecret
 metadata:
   creationTimestamp: null
-  name: buoyant-license
+  name: buoyant-enterprise-license
   namespace: linkerd
 spec:
   encryptedData:
@@ -11,5 +11,5 @@ spec:
   template:
     metadata:
       creationTimestamp: null
-      name: buoyant-license
+      name: buoyant-enterprise-license
       namespace: linkerd

--- a/flux/helm-example/apps/linkerd/linkerd-issuers-certs.yaml
+++ b/flux/helm-example/apps/linkerd/linkerd-issuers-certs.yaml
@@ -23,12 +23,6 @@ spec:
   privateKey:
     algorithm: ECDSA
   secretName: linkerd-identity-trust-anchor
-  secretTemplate:
-    annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cert-manager,linkerd"  # Control destination namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cert-manager,linkerd" # Control auto-reflection namespaces
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/linkerd-tls-automation-examples/cert-manager/cert-manager-rbac.yaml
+++ b/linkerd-tls-automation-examples/cert-manager/cert-manager-rbac.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cert-manager
+  namespace: linkerd
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cert-manager-secret-creator
+  namespace: linkerd
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["create", "get", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: cert-manager-secret-creator-binding
+  namespace: linkerd
+subjects:
+  - kind: ServiceAccount
+    name: cert-manager
+    namespace: linkerd
+roleRef:
+  kind: Role
+  name: cert-manager-secret-creator
+  apiGroup: rbac.authorization.k8s.io

--- a/linkerd-tls-automation-examples/cert-manager/linkerd-issuers-certs.yaml
+++ b/linkerd-tls-automation-examples/cert-manager/linkerd-issuers-certs.yaml
@@ -23,12 +23,6 @@ spec:
   privateKey:
     algorithm: ECDSA
   secretName: linkerd-identity-trust-anchor
-  secretTemplate:
-    annotations:
-      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "cert-manager,linkerd"  # Control destination namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true" # Auto create reflection for matching namespaces
-      reflector.v1.k8s.emberstack.com/reflection-auto-namespaces: "cert-manager,linkerd" # Control auto-reflection namespaces
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer


### PR DESCRIPTION
Fixed and standardized licenseSecret names as `buoyant-enterprise-license`, added RBAC for cert-manager to allow creation of secrets in `linkerd` ns without need of external tools like Reflector, and added cert-manager RBAC example to linkerd-tls-automation-examples dir